### PR TITLE
Refactor server bootstrap

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,27 @@
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import promise from 'eslint-plugin-promise';
+import n from 'eslint-plugin-n';
+
+export default [
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        project: './tsconfig.json'
+      }
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      promise,
+      n
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      'no-console': 'warn'
+    }
+  }
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,9 @@
-import Fastify from 'fastify';
 import { config } from 'dotenv';
-import swagger from './plugins/swagger.js';
+import { buildServer } from './server.js';
 
 config();
 
-const app = Fastify();
-
-app.register(swagger);
-
-app.get('/health', async () => ({ ok: true }));
+const app = buildServer();
 
 const start = async () => {
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,12 @@
+import Fastify, { FastifyInstance } from 'fastify';
+import swagger from './plugins/swagger.js';
+
+export function buildServer(): FastifyInstance {
+  const app = Fastify();
+
+  app.register(swagger);
+
+  app.get('/health', async () => ({ ok: true }));
+
+  return app;
+}


### PR DESCRIPTION
## Summary
- create `buildServer()` in `server.ts`
- update entrypoint to use the new bootstrap
- add an ESLint flat config
- remove contributor comments

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b9c97d9a483238c344a6c8c75fd1d