### PR TITLE
Fix startup error handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,10 @@ const start = async () => {
   try {
     await app.listen({ port: Number(env.PORT), host: '0.0.0.0' });
     app.log.info('Server listening');
-  } catch (err) {
+  } catch (err: unknown) {
     app.log.error(err);
-    process.exit(1);
+    process.exitCode = 1;
+    throw err;
   }
 };
 


### PR DESCRIPTION
## Summary
- ensure server startup logs and rethrows errors without exiting

## Testing
- `npm run lint` *(fails: n/no-unpublished-import)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bcb4a593883239a25299ff694d026