### PR TITLE
Add missing env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 PORT=3000
 NODE_ENV=development
+INTERNAL_SERVICE_URL=http://localhost:4000


### PR DESCRIPTION
Adds `INTERNAL_SERVICE_URL` to `.env.example` so all required environment variables are documented.

------
https://chatgpt.com/codex/tasks/task_e_6884e5f0256c83239630ee7482f4762b