### PR TITLE
Add user registration endpoint

### DIFF
--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -1,0 +1,24 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { registerUser } from '../services/registerService.js';
+
+const bodySchema = z.object({
+  name: z.string(),
+  username: z.string(),
+  authUserId: z.string().uuid(),
+  country: z.string()
+});
+
+export default async function registerRoutes(app: FastifyInstance) {
+  app.post('/register', async (request, reply) => {
+    try {
+      const body = bodySchema.parse(request.body);
+      const data = await registerUser(body);
+      return { ok: true, data };
+    } catch (err) {
+      request.log.error(err);
+      reply.code(500);
+      return { ok: false, error: 'Registration failed', status: 500 };
+    }
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import Fastify, { FastifyInstance } from 'fastify';
 import swagger from './plugins/swagger.js';
 import auth from './plugins/auth.js';
 import exampleRoutes from './routes/example.js';
+import registerRoutes from './routes/register.js';
 
 export function buildServer(): FastifyInstance {
   const app = Fastify();
@@ -12,6 +13,7 @@ export function buildServer(): FastifyInstance {
   app.get('/health', async () => ({ ok: true }));
 
   app.register(exampleRoutes);
+  app.register(registerRoutes);
 
   return app;
 }

--- a/src/services/registerService.ts
+++ b/src/services/registerService.ts
@@ -1,0 +1,44 @@
+import {
+  disCreateUser,
+  disAssignRole,
+  disSetPreference,
+  disSetSocials,
+  Role,
+  PreferencePayload,
+  SocialPayload
+} from '../utils/disClient.js';
+import type { RegisterInput, RegisterResponse } from '../types/register.js';
+
+const defaultRole: Role = 'node';
+
+const defaultPreference: PreferencePayload = {
+  receiveUpdates: true,
+  acceptTerms: true,
+  acceptGdpr: true,
+  darkModeEnabled: true,
+  language: 'en',
+  betaFeaturesEnabled: false,
+  timezone: 'Europe/Bucharest'
+};
+
+const defaultSocials: SocialPayload = {
+  platform: 'x',
+  handle: '@example',
+  verified: false,
+  url: ''
+};
+
+export async function registerUser(
+  input: RegisterInput
+): Promise<RegisterResponse> {
+  try {
+    const user = await disCreateUser(input);
+    const userId = Number(user.userId);
+    await disAssignRole(userId, defaultRole);
+    await disSetPreference(userId, defaultPreference);
+    await disSetSocials(userId, defaultSocials);
+    return user;
+  } catch {
+    throw new Error('User registration failed');
+  }
+}

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -1,0 +1,17 @@
+export interface RegisterInput {
+  name: string;
+  username: string;
+  authUserId: string;
+  country: string;
+}
+
+export interface DisUser {
+  userId: number;
+  name: string;
+  username: string;
+  authUserId: string;
+  country: string;
+  [key: string]: unknown;
+}
+
+export type RegisterResponse = DisUser;

--- a/src/utils/disClient.ts
+++ b/src/utils/disClient.ts
@@ -1,0 +1,59 @@
+import { callInternal } from './callInternal.js';
+import type { RegisterInput, DisUser } from '../types/register.js';
+
+export async function disCreateUser(data: RegisterInput): Promise<DisUser> {
+  return callInternal<DisUser>({
+    method: 'POST',
+    path: '/user/',
+    body: data
+  });
+}
+
+export type Role = 'miner' | 'validator' | 'node';
+
+export async function disAssignRole(userId: number, role: Role): Promise<void> {
+  await callInternal({
+    method: 'POST',
+    path: `/user/${userId}/roles`,
+    body: { role }
+  });
+}
+
+export interface PreferencePayload {
+  receiveUpdates: boolean;
+  acceptTerms: boolean;
+  acceptGdpr: boolean;
+  darkModeEnabled: boolean;
+  language: string;
+  betaFeaturesEnabled: boolean;
+  timezone: string;
+}
+
+export async function disSetPreference(
+  userId: number,
+  prefs: PreferencePayload
+): Promise<void> {
+  await callInternal({
+    method: 'POST',
+    path: `/user/${userId}/preference`,
+    body: prefs
+  });
+}
+
+export interface SocialPayload {
+  platform: string;
+  handle: string;
+  verified: boolean;
+  url: string;
+}
+
+export async function disSetSocials(
+  userId: number,
+  socials: SocialPayload
+): Promise<void> {
+  await callInternal({
+    method: 'POST',
+    path: `/user/${userId}/socials`,
+    body: socials
+  });
+}

--- a/tests/register.test.ts
+++ b/tests/register.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/services/registerService.js', () => ({
+  registerUser: vi.fn()
+}));
+
+import { buildServer } from '../src/server.js';
+import { registerUser } from '../src/services/registerService.js';
+
+const mockedRegisterUser = registerUser as unknown as ReturnType<typeof vi.fn>;
+
+const payload = {
+  name: 'John Doe',
+  username: 'johndoe',
+  authUserId: '11111111-1111-1111-8111-111111111111',
+  country: 'US'
+};
+
+describe('POST /register', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a user', async () => {
+    mockedRegisterUser.mockResolvedValueOnce({ userId: 1, ...payload });
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/register',
+      payload
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.json()).toEqual({ ok: true, data: { userId: 1, ...payload } });
+    expect(mockedRegisterUser).toHaveBeenCalledWith(payload);
+  });
+
+  it('handles errors', async () => {
+    mockedRegisterUser.mockRejectedValueOnce(new Error('fail'));
+    const app = buildServer();
+    const res = await app.inject({ method: 'POST', url: '/register', payload });
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toEqual({ ok: false, error: 'Registration failed', status: 500 });
+  });
+});


### PR DESCRIPTION
## Summary
- register new users via DIS
- add DIS client utilities
- wire up the `/register` route
- cover registration logic with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884f000145483238f749e27319427ed