### PR TITLE
Add user resource with service and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ Set these values in `.env` as needed:
    ```bash
    curl http://localhost:3000/example?name=John
    ```
+5. Create a user:
+   ```bash
+   curl -X POST http://localhost:3000/users \
+     -H 'Content-Type: application/json' \
+     -d '{"name":"John","username":"johnny"}'
+   ```
+6. Fetch a user:
+   ```bash
+   curl http://localhost:3000/users/1
+   ```
 Routes are organized in `src/routes` and forward logic to `src/services`, which talk to the internal API via `callInternal`.
 
 ---
@@ -96,5 +106,6 @@ See [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md) for setup, code style, and 
 ## Status
 
 - ✅ Health check and example routes implemented
+- ✅ User creation and fetch routes available
 - 🔒 Connects to the Dorsium Internal Service through `callInternal`
 - 📘 Swagger auto-doc enabled

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -1,0 +1,38 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { registerUser, getUser } from '../services/userService.js';
+
+const createSchema = z.object({
+  name: z.string(),
+  username: z.string()
+});
+
+const paramsSchema = z.object({
+  id: z.coerce.number()
+});
+
+export default async function userRoutes(app: FastifyInstance) {
+  app.post('/users', async (request, reply) => {
+    try {
+      const body = createSchema.parse(request.body);
+      const data = await registerUser(body);
+      return { ok: true, data };
+    } catch (err) {
+      request.log.error(err);
+      reply.code(500);
+      return { ok: false, error: 'User creation failed', status: 500 };
+    }
+  });
+
+  app.get('/users/:id', async (request, reply) => {
+    try {
+      const { id } = paramsSchema.parse(request.params);
+      const data = await getUser(id);
+      return { ok: true, data };
+    } catch (err) {
+      request.log.error(err);
+      reply.code(500);
+      return { ok: false, error: 'User fetch failed', status: 500 };
+    }
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import swagger from './plugins/swagger.js';
 import auth from './plugins/auth.js';
 import exampleRoutes from './routes/example.js';
 import registerRoutes from './routes/register.js';
+import userRoutes from './routes/user.js';
 
 export function buildServer(): FastifyInstance {
   const app = Fastify();
@@ -14,6 +15,7 @@ export function buildServer(): FastifyInstance {
 
   app.register(exampleRoutes);
   app.register(registerRoutes);
+  app.register(userRoutes);
 
   return app;
 }

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,0 +1,17 @@
+import { callInternal } from '../utils/callInternal.js';
+import type { UserInput, UserResponse } from '../types/user.js';
+
+export async function registerUser(input: UserInput): Promise<UserResponse> {
+  return callInternal<UserResponse>({
+    method: 'POST',
+    path: '/users',
+    body: input
+  });
+}
+
+export async function getUser(id: number): Promise<UserResponse> {
+  return callInternal<UserResponse>({
+    method: 'GET',
+    path: `/users/${id}`
+  });
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,13 @@
+export interface UserInput {
+  name: string;
+  username: string;
+}
+
+export interface User {
+  id: number;
+  name: string;
+  username: string;
+  [key: string]: unknown;
+}
+
+export type UserResponse = User;

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/services/userService.js', () => ({
+  registerUser: vi.fn(),
+  getUser: vi.fn()
+}));
+
+import { buildServer } from '../src/server.js';
+import { registerUser, getUser } from '../src/services/userService.js';
+
+const mockedRegisterUser = registerUser as unknown as ReturnType<typeof vi.fn>;
+const mockedGetUser = getUser as unknown as ReturnType<typeof vi.fn>;
+
+const payload = { name: 'Jane', username: 'jane' };
+
+describe('POST /users', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a user', async () => {
+    mockedRegisterUser.mockResolvedValueOnce({ id: 1, ...payload });
+    const app = buildServer();
+    const res = await app.inject({ method: 'POST', url: '/users', payload });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true, data: { id: 1, ...payload } });
+    expect(mockedRegisterUser).toHaveBeenCalledWith(payload);
+  });
+
+  it('handles errors', async () => {
+    mockedRegisterUser.mockRejectedValueOnce(new Error('fail'));
+    const app = buildServer();
+    const res = await app.inject({ method: 'POST', url: '/users', payload });
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toEqual({ ok: false, error: 'User creation failed', status: 500 });
+  });
+});
+
+describe('GET /users/:id', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns user data', async () => {
+    mockedGetUser.mockResolvedValueOnce({ id: 2, ...payload });
+    const app = buildServer();
+    const res = await app.inject({ method: 'GET', url: '/users/2' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true, data: { id: 2, ...payload } });
+    expect(mockedGetUser).toHaveBeenCalledWith(2);
+  });
+
+  it('handles errors', async () => {
+    mockedGetUser.mockRejectedValueOnce(new Error('fail'));
+    const app = buildServer();
+    const res = await app.inject({ method: 'GET', url: '/users/2' });
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toEqual({ ok: false, error: 'User fetch failed', status: 500 });
+  });
+});


### PR DESCRIPTION
## Summary
- add `userService` with register & fetch helpers
- create `user` routes and wire them up
- expose new endpoints in README and server
- define `User` types and add test coverage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884f73d312c832391098c68f6cfea56