### PR TITLE
Add auth middleware tests

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -13,11 +13,13 @@ export function buildServer(): FastifyInstance {
   app.register(auth);
   app.register(rateLimit);
 
-  app.get('/health', async () => ({ ok: true }));
+  app.after(() => {
+    app.get('/health', async () => ({ ok: true }));
 
-  app.register(exampleRoutes);
-  app.register(registerRoutes);
-  app.register(userRoutes);
+    app.register(exampleRoutes);
+    app.register(registerRoutes);
+    app.register(userRoutes);
+  });
 
   return app;
 }

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { buildServer } from '../src/server.js';
+
+function setupApp() {
+  const app = buildServer();
+  app.after(() => {
+    app.get('/protected', { preHandler: app.authenticate }, async () => ({ ok: true }));
+  });
+  return app;
+}
+
+describe('authenticate', () => {
+  it('rejects invalid tokens', async () => {
+    const app = setupApp();
+    await app.ready();
+    const res = await app.inject({ method: 'GET', url: '/protected', headers: { authorization: 'Bearer invalid' } });
+    expect(res.statusCode).toBe(401);
+    expect(res.json()).toEqual({ ok: false, error: 'Unauthorized', status: 401 });
+  });
+
+  it('allows valid tokens', async () => {
+    const app = setupApp();
+    await app.ready();
+    const token = await app.jwt.sign({ id: 1 });
+    const res = await app.inject({ method: 'GET', url: '/protected', headers: { authorization: `Bearer ${token}` } });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary
- test JWT authentication success and failure
- ensure plugins load before routes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885168cb8b48323b79808b403f02df8