### PR TITLE
Add user schemas to Swagger and reference routes

### DIFF
--- a/src/plugins/swagger.ts
+++ b/src/plugins/swagger.ts
@@ -1,18 +1,94 @@
 import { FastifyInstance } from 'fastify';
+import fastifyPlugin from 'fastify-plugin';
 import fastifySwagger, { SwaggerOptions } from '@fastify/swagger';
 import fastifySwaggerUi from '@fastify/swagger-ui';
 
-export default async function swagger(app: FastifyInstance) {
+async function swagger(app: FastifyInstance) {
+  const userSchemas = [
+    {
+      $id: 'User',
+      type: 'object',
+      properties: {
+        id: { type: 'integer' },
+        name: { type: 'string' },
+        username: { type: 'string' }
+      },
+      required: ['id', 'name', 'username']
+    },
+    {
+      $id: 'UserInput',
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        username: { type: 'string' }
+      },
+      required: ['name', 'username']
+    },
+    {
+      $id: 'LoginInput',
+      type: 'object',
+      properties: {
+        username: { type: 'string' },
+        password: { type: 'string' }
+      },
+      required: ['username', 'password']
+    },
+    {
+      $id: 'LoginResponse',
+      type: 'object',
+      properties: {
+        token: { type: 'string' }
+      },
+      required: ['token']
+    }
+    ,
+    {
+      $id: 'UserResponse',
+      type: 'object',
+      properties: {
+        ok: { type: 'boolean' },
+        data: { $ref: 'User' }
+      },
+      required: ['ok', 'data']
+    },
+    {
+      $id: 'TokenResponse',
+      type: 'object',
+      properties: {
+        ok: { type: 'boolean' },
+        data: { $ref: 'LoginResponse' }
+      },
+      required: ['ok', 'data']
+    }
+  ];
+
   const swaggerOptions: SwaggerOptions = {
     openapi: {
       info: {
         title: 'Dorsium API',
         description: 'Dorsium API docs',
         version: '1.0.0'
+      },
+      components: {
+        schemas: {
+          User: { $ref: 'User' },
+          UserInput: { $ref: 'UserInput' },
+          LoginInput: { $ref: 'LoginInput' },
+          LoginResponse: { $ref: 'LoginResponse' },
+          UserResponse: { $ref: 'UserResponse' },
+          TokenResponse: { $ref: 'TokenResponse' }
+        }
+      }
+    },
+    refResolver: {
+      buildLocalReference(json, _baseUri, _fragment, i) {
+        return String(json.$id || `def-${i}`);
       }
     }
   };
   await app.register(fastifySwagger, swaggerOptions);
+
+  userSchemas.forEach((schema) => app.addSchema(schema));
 
   await app.register(fastifySwaggerUi, {
     routePrefix: '/docs',
@@ -23,3 +99,5 @@ export default async function swagger(app: FastifyInstance) {
     staticCSP: true
   });
 }
+
+export default fastifyPlugin(swagger);

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -21,7 +21,13 @@ const loginSchema = z.object({
 });
 
 export default async function userRoutes(app: FastifyInstance) {
-  app.post('/users', async (request, reply) => {
+  app.post('/users', {
+    schema: {
+      tags: ['User'],
+      body: { $ref: 'UserInput' },
+      response: { 200: { $ref: 'UserResponse' } }
+    }
+  }, async (request, reply) => {
     try {
       const body = createSchema.parse(request.body);
       const data = await registerUser(body);
@@ -33,7 +39,13 @@ export default async function userRoutes(app: FastifyInstance) {
     }
   });
 
-  app.post('/login', async (request, reply) => {
+  app.post('/login', {
+    schema: {
+      tags: ['User'],
+      body: { $ref: 'LoginInput' },
+      response: { 200: { $ref: 'TokenResponse' } }
+    }
+  }, async (request, reply) => {
     try {
       const body = loginSchema.parse(request.body);
       const user = await verifyCredentials(body);
@@ -46,7 +58,17 @@ export default async function userRoutes(app: FastifyInstance) {
     }
   });
 
-  app.get('/users/:id', async (request, reply) => {
+  app.get('/users/:id', {
+    schema: {
+      tags: ['User'],
+      params: {
+        type: 'object',
+        properties: { id: { type: 'integer' } },
+        required: ['id']
+      },
+      response: { 200: { $ref: 'UserResponse' } }
+    }
+  }, async (request, reply) => {
     try {
       const { id } = paramsSchema.parse(request.params);
       const data = await getUser(id);


### PR DESCRIPTION
## Summary
- define reusable Swagger schemas for user data and login tokens
- reference schemas from user routes with descriptive tags

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `curl -s http://localhost:3000/docs | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68853b58cc188323bbb0f8ca7f8a7932